### PR TITLE
Upgrade Android project setup & fix NPE

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'net.zonble.flutterinstallappplugin'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/src/main/kotlin/net/zonble/flutterinstallappplugin/FlutterInstallAppPlugin.kt
+++ b/android/src/main/kotlin/net/zonble/flutterinstallappplugin/FlutterInstallAppPlugin.kt
@@ -3,22 +3,22 @@ package net.zonble.flutterinstallappplugin
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class FlutterInstallAppPlugin(private val activity: Activity) : MethodCallHandler {
     companion object {
         @JvmStatic
-        fun registerWith(registrar: Registrar): Unit {
+        fun registerWith(registrar: Registrar) {
             val channel = MethodChannel(registrar.messenger(), "flutter_install_app_plugin")
             channel.setMethodCallHandler(FlutterInstallAppPlugin(registrar.activity()))
         }
     }
 
-    override fun onMethodCall(call: MethodCall, result: Result): Unit {
+    override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "installApp" -> {
                 val args = call.arguments as? ArrayList<*>

--- a/android/src/main/kotlin/net/zonble/flutterinstallappplugin/FlutterInstallAppPlugin.kt
+++ b/android/src/main/kotlin/net/zonble/flutterinstallappplugin/FlutterInstallAppPlugin.kt
@@ -13,8 +13,11 @@ class FlutterInstallAppPlugin(private val activity: Activity) : MethodCallHandle
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar) {
-            val channel = MethodChannel(registrar.messenger(), "flutter_install_app_plugin")
-            channel.setMethodCallHandler(FlutterInstallAppPlugin(registrar.activity()))
+            val activity = registrar.activity()
+            if (activity != null) {
+                val channel = MethodChannel(registrar.messenger(), "flutter_install_app_plugin")
+                channel.setMethodCallHandler(FlutterInstallAppPlugin(activity))
+            }
         }
     }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
         targetSdkVersion 27
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -62,6 +62,6 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/example/android/app/src/main/kotlin/flutterinstallappplugin/zonble/net/flutterinstallapppluginexample/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/flutterinstallappplugin/zonble/net/flutterinstallapppluginexample/MainActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import io.flutter.app.FlutterActivity
 import io.flutter.plugins.GeneratedPluginRegistrant
 
-class MainActivity(): FlutterActivity() {
+class MainActivity : FlutterActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     GeneratedPluginRegistrant.registerWith(this)

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,3 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
- upgrade the Android project tooling to the latest version
- migrate to AndroidX
- Resolve a NPE when the plugin is started in a background isolate (e.g. in a `Service`)